### PR TITLE
Fix odometry state updates in Unitree envs

### DIFF
--- a/robojudo/environment/unitree_cpp_env.py
+++ b/robojudo/environment/unitree_cpp_env.py
@@ -128,7 +128,7 @@ class UnitreeCppEnv(Environment):
             if self.zed_odometry.is_valid:
                 # born place aligned in zed_odometry
                 self._base_pos = self.zed_odometry.pos
-                self._lin_vel = self.zed_odometry.lin_vel
+                self._base_lin_vel = self.zed_odometry.lin_vel
         elif self._odometry_type == "DUMMY":
             self._base_pos = np.array([0.0, 0.0, 0.8])
             self._base_lin_vel = np.array([0.0, 0.0, 0.0])
@@ -137,8 +137,7 @@ class UnitreeCppEnv(Environment):
             base_pos = np.asarray(self.sport_state.position, dtype=np.float32)
             lin_vel = np.asarray(self.sport_state.velocity, dtype=np.float32)
             self._base_lin_vel = quat_rotate_inverse_np(self.base_quat, lin_vel)
-            if self.born_place_align:
-                self._base_pos = self.base_align.align_pos(base_pos)
+            self._base_pos = self.base_align.align_pos(base_pos) if self.born_place_align else base_pos
 
         # FK
         if self.update_with_fk:

--- a/robojudo/environment/unitree_env.py
+++ b/robojudo/environment/unitree_env.py
@@ -259,7 +259,7 @@ class UnitreeEnv(Environment):
             if self.zed_odometry.is_valid:
                 # born place aligned in zed_odometry
                 self._base_pos = self.zed_odometry.pos
-                self._lin_vel = self.zed_odometry.lin_vel
+                self._base_lin_vel = self.zed_odometry.lin_vel
         elif self._odometry_type == "DUMMY":
             self._base_pos = np.array([0.0, 0.0, 0.8])
             self._base_lin_vel = np.array([0.0, 0.0, 0.0])
@@ -267,8 +267,7 @@ class UnitreeEnv(Environment):
             base_pos = np.array(self.sport_state.position, dtype=np.float32)
             lin_vel = np.array(self.sport_state.velocity, dtype=np.float32)
             self._base_lin_vel = quat_rotate_inverse_np(self.base_quat, lin_vel)
-            if self.born_place_align:
-                self._base_pos = self.base_align.align_pos(base_pos)
+            self._base_pos = self.base_align.align_pos(base_pos) if self.born_place_align else base_pos
 
         # FK
         if self.update_with_fk:


### PR DESCRIPTION
## Summary
- fix ZED odometry updates to write `base_lin_vel` instead of the unused `_lin_vel`
- ensure UNITREE odometry always updates `base_pos`, with alignment applied only when enabled

## Problem
`base_lin_vel` was not updated in the ZED path because the code wrote to `_lin_vel`, which is not exposed by the environment base class.

Also, in the UNITREE path, `base_pos` was only updated when `born_place_align` was enabled, which could leave stale or missing position data when alignment was disabled.