### PR TITLE
fix(prepare function consuming frames)

### DIFF
--- a/robojudo/pipeline/rl_pipeline.py
+++ b/robojudo/pipeline/rl_pipeline.py
@@ -197,7 +197,7 @@ class RlPipeline(Pipeline):
             last_step_time = time.time()
             pbar.update()
 
-            if t == 0.9 * traj_len:
+            if t == traj_len - 1:
                 logger.info(f"{'=' * 10} RESET ZERO POSITION {'=' * 10}")
                 self.reset()
 
@@ -205,6 +205,22 @@ class RlPipeline(Pipeline):
         pbar.close()
         logger.warning("prepare_done")
 
+        # pause motion reference playback 0 and start balancing
+        if hasattr(self.policy.policy, "set_pause"):
+            balance_time = 3.0
+            self.policy.reset_alignment()
+            self.policy.policy.set_pause(True)
+            logger.warning("controller_start")
+            logger.info("Motion playback paused - balancing robot at init pose")
+            last_step_time = time.time()
+            for _ in range(int(self.freq * balance_time)):
+                self.step()
+                time_diff = last_step_time + self.dt - time.time()
+                if time_diff > 0:
+                    time.sleep(time_diff)
+                last_step_time = time.time()
+            self.policy.policy.set_pause(False)
+            logger.info("Motion playback starting")
 
 if __name__ == "__main__":
     pass

--- a/robojudo/policy/protomotions_tracker_policy.py
+++ b/robojudo/policy/protomotions_tracker_policy.py
@@ -289,3 +289,6 @@ class ProtoMotionsTrackerPolicy(Policy):
 
     def get_init_dof_pos(self):
         return self._player.get_state_at_frame(0)["dof_pos"].copy()
+    
+    def set_pause(self, pause: bool = True):
+        self._paused = pause


### PR DESCRIPTION
- fixed the error that caused prepare function to consume the first 100 frames of the motion file, by only calling reset at the end of prepare
- updated ProtoMotionsTrackerPolicy with a set_pause function
- updated the prepare function to pause the motion before starting the controller policy, self balance for 3s (can be set), and only then start the playback of the motion file
- tested on real G1 robot with the protomotions tracker policy