### PR TITLE
Remove protomotions dependency for tracker inference

### DIFF
--- a/robojudo/config/g1/g1_cfg.py
+++ b/robojudo/config/g1/g1_cfg.py
@@ -69,7 +69,7 @@ class g1_real(g1):
         # env_type="UnitreeEnv",  # For unitree_sdk2py
         env_type="UnitreeCppEnv",  # For unitree_cpp, check README for more details
         unitree=G1UnitreeCfg(
-            net_if="eth0",  # note: change to your network interface
+            net_if="eth0",
         ),
     )
 
@@ -348,16 +348,29 @@ class g1_protomotions_tracker(RlPipelineCfg):
 
     Usage::
 
-        cd robojudo && python scripts/run_tracker_pipeline.py \\
-            -c g1_protomotions_tracker \\
+        cd robojudo && python scripts/run_pipeline.py -c g1_protomotions_tracker \\
             --onnx-path /path/to/unified_pipeline.onnx \\
             --motion-path /path/to/motion.motion
     """
 
     robot: str = "g1"
-    env: G1MujocoEnvCfg = G1MujocoEnvCfg(born_place_align=False)
+    env: G1MujocoEnvCfg = G1MujocoEnvCfg(
+        born_place_align=False,
+        random_heading=True,
+    )
+    ctrl: list[KeyboardCtrlCfg] = [
+        KeyboardCtrlCfg(
+            triggers={
+                "r": "[MOTION_RESET]",
+                "i": "[SIM_REBORN]",
+                "o": "[SHUTDOWN]",
+                "<": "[MOTION_FADE_IN]",
+                ">": "[MOTION_FADE_OUT]",
+            },
+        ),
+    ]
+
     policy: ProtoMotionsTrackerPolicyCfg = ProtoMotionsTrackerPolicyCfg()
-    ctrl: list[KeyboardCtrlCfg] = [KeyboardCtrlCfg()]
 
 
 @cfg_registry.register
@@ -366,8 +379,7 @@ class g1_protomotions_tracker_real(g1_protomotions_tracker):
 
     Usage::
 
-        cd robojudo && python scripts/run_tracker_pipeline.py \\
-            -c g1_protomotions_tracker_real \\
+        cd robojudo && python scripts/run_pipeline.py -c g1_protomotions_tracker_real \\
             --onnx-path /path/to/unified_pipeline.onnx \\
             --motion-path /path/to/motion.motion
     """

--- a/robojudo/environment/env_cfgs.py
+++ b/robojudo/environment/env_cfgs.py
@@ -36,6 +36,9 @@ class MujocoEnvCfg(EnvCfg):
 
     visualize_extras: bool = True  # TODO: remove
 
+    random_heading: bool = False
+    """Randomize the robot's yaw heading on each spawn/reborn (useful for testing heading alignment)."""
+
 
 class RobotEnvCfg(EnvCfg):
     env_type: str = "DummyEnv"

--- a/robojudo/environment/mujoco_env.py
+++ b/robojudo/environment/mujoco_env.py
@@ -50,8 +50,24 @@ class MujocoEnv(Environment):
             self.visualizer = None
 
         self.last_time = time.time()
+        self.random_heading = cfg_env.random_heading
+
+        self._apply_random_heading()
 
         self.update()  # get initial state
+
+    def _apply_random_heading(self):
+        """Rotate the root body by a random yaw if random_heading is enabled."""
+        if not self.random_heading:
+            return
+        yaw = np.random.uniform(0, 2 * np.pi)
+        c, s = np.cos(yaw / 2), np.sin(yaw / 2)
+        q = self.data.qpos[3:7].copy()  # MuJoCo [w, x, y, z]
+        # Pre-multiply by yaw rotation q_yaw=[c,0,0,s]: q_new = q_yaw ⊗ q
+        self.data.qpos[3] = c * q[0] - s * q[3]
+        self.data.qpos[4] = c * q[1] - s * q[2]
+        self.data.qpos[5] = c * q[2] + s * q[1]
+        self.data.qpos[6] = c * q[3] + s * q[0]
 
     def reborn(self, init_qpos=None):
         if init_qpos is not None:
@@ -60,6 +76,7 @@ class MujocoEnv(Environment):
             self.data.ctrl[:] = 0.0
         else:
             mujoco.mj_resetDataKeyframe(self.model, self.data, 0)  # pyright: ignore[reportAttributeAccessIssue]
+            self._apply_random_heading()
         mujoco.mj_forward(self.model, self.data)  # pyright: ignore[reportAttributeAccessIssue]
 
     def reset(self):

--- a/robojudo/pipeline/rl_pipeline.py
+++ b/robojudo/pipeline/rl_pipeline.py
@@ -85,22 +85,53 @@ class RlPipeline(Pipeline):
         self.freq = self.cfg.policy.freq
         self.dt = 1.0 / self.freq
 
-        self.self_check()
         self.reset()
+        self.self_check()
+        self.policy.reset()  # reset frame counter after dry-run steps
 
     def self_check(self):
         self.env.self_check()
         for _ in range(10):
             self.step(dry_run=True)
 
+    def _inner_policy(self):
+        """Return the unwrapped inner Policy (e.g. ProtoMotionsTrackerPolicy)."""
+        return getattr(self.policy, "policy", self.policy)
+
+    @property
+    def _has_default_pose_mode(self) -> bool:
+        return hasattr(self._inner_policy(), "set_default_pose_mode")
+
+    def _set_default_pose_mode(self, enabled: bool):
+        """Enable/disable default-pose mode on the inner policy (if supported)."""
+        inner = self._inner_policy()
+        if hasattr(inner, "set_default_pose_mode"):
+            inner.set_default_pose_mode(enabled)
+
     def reset(self):
         logger.info("Pipeline reset")
         self.timestep = 0
 
         self.env.reset()
-        # self.env.reborn(init_qpos=[0.2, 0.2, 0.8] + [ 0.707, 0, 0, 0.707]) # FOR SIM DEBUG
         self.policy.reset()
         self.ctrl_manager.reset()
+
+        # Blend-out state: transitions policy → init pose at end of motion.
+        self._blend_out_active = False
+        self._blend_out_step = 0
+        self._blend_out_duration = int(5.0 * self.freq)  # 5 seconds
+
+        # For tracker policies with default-pose mode, ramp/blend target is
+        # the env's default standing pose.  Otherwise, use motion frame 0.
+        if self._has_default_pose_mode:
+            self._init_dof_pos = np.asarray(self.env.dof_cfg.default_pos, dtype=np.float32)
+        else:
+            self._init_dof_pos = np.asarray(self.policy.get_init_dof_pos(), dtype=np.float32)
+
+        self._pending_blend_in = False
+        self._blend_in_completed = False
+        self._user_fade_out = False  # True when fade-out was user-triggered (not auto)
+        self._prepare_seconds = None  # set by prepare() for re-use on reset
 
     def safety_check(self):
         if not self.do_safety_check:
@@ -128,6 +159,36 @@ class RlPipeline(Pipeline):
                         logger.warning("Simulation Env reborn!")
                         self.env.reborn()  # pyright: ignore[reportAttributeAccessIssue]
                         self.policy.reset_alignment()
+                case "[MOTION_RESET]" | "[MOTION_FADE_IN]":
+                    self._blend_out_active = False
+                    self._blend_out_step = 0
+                    self._user_fade_out = False
+                    if self._has_default_pose_mode:
+                        # Policy is already active — just switch target
+                        # from default pose to motion (instant, no blend).
+                        logger.info(
+                            f"{command} — starting motion from frame 0"
+                        )
+                        self._set_default_pose_mode(False)
+                    else:
+                        # Legacy path: full blend-in needed.
+                        logger.info(
+                            f"{command} — re-entering blend-in phase"
+                        )
+                        self._pending_blend_in = True
+                case "[MOTION_FADE_OUT]":
+                    if self._has_default_pose_mode:
+                        logger.info("Fade out — switching to default pose mode")
+                        self._set_default_pose_mode(True)
+                        self._user_fade_out = True
+                    elif not self._blend_out_active:
+                        logger.info("Fade out — blending to default pose")
+                        self._blend_out_active = True
+                        self._blend_out_step = 0
+                        self._user_fade_out = True
+                        inner = self._inner_policy()
+                        if hasattr(inner, "_paused"):
+                            inner._paused = True
 
         self.ctrl_manager.post_step_callback(ctrl_data)
 
@@ -158,34 +219,60 @@ class RlPipeline(Pipeline):
         obs, extras = self.policy.get_observation(env_data, ctrl_data)
         pd_target = self.policy.get_pd_target(obs)
 
+        # -- Detect motion done --
+        callbacks = extras.get("CALLBACK", [])
+        if "[MOTION_DONE]" in callbacks and not self._blend_out_active:
+            if self._has_default_pose_mode:
+                logger.info("Motion done — switching to default pose mode")
+                self._set_default_pose_mode(True)
+            else:
+                logger.info("Motion done — blending out to default pose")
+                self._blend_out_active = True
+                self._blend_out_step = 0
+
+        # -- Blend policy output → init pose (frame 0) --
+        if self._blend_out_active:
+            alpha = min(self._blend_out_step / max(self._blend_out_duration, 1), 1.0)
+            pd_target = (1 - alpha) * pd_target + alpha * self._init_dof_pos
+            self._blend_out_step += 1
+
         if not dry_run:
             self.env.step(pd_target, extras.get("hand_pose", None))
 
         self.post_step_callback(env_data, ctrl_data, extras, pd_target)
 
-    def prepare(self, init_motor_angle=None):
-        if init_motor_angle is not None:
-            desired_motor_angle = init_motor_angle
-        else:
-            desired_motor_angle = self.policy.get_init_dof_pos()
+        # Handle pending blend-in (after MOTION_RESET / FADE_IN).
+        if self._pending_blend_in:
+            self._pending_blend_in = False
+            self._run_blend_in()
+            self._blend_in_completed = True
 
-        # logger.info(f"{desired_motor_angle=}")
-        current_motor_angle = np.array(self.env.dof_pos)
-        # logger.info(f"{current_motor_angle=}")
+    def _run_blend_in(self):
+        """Phase 2 of prepare: blend from default pose to policy output.
 
-        traj_len = 1000
+        Policy runs in default-pose mode (if supported); frame stays at 0
+        (no post_step_callback).  After blend, switches to motion tracking.
+        """
+        secs = self._prepare_seconds or 3.0
+        blend_steps = int(secs * self.freq)
+
+        # Enter default-pose mode for the blend-in period.
+        self._set_default_pose_mode(True)
+
+        logger.warning(f"Blend-in: default DOF → policy ({blend_steps} steps, {secs:.1f}s)")
+        pbar = ProgressBar("Blend in", blend_steps)
+
         last_step_time = time.time()
-        logger.warning("prepare_init")
-        pbar = ProgressBar("Prepare", traj_len)
+        for t in range(blend_steps):
+            alpha = t / max(blend_steps - 1, 1)
 
-        for t in range(traj_len):
-            current_motor_angle = np.array(self.env.dof_pos)
+            self.env.update()
+            env_data = self.env.get_data()
+            ctrl_data = self.ctrl_manager.get_ctrl_data(env_data)
+            obs, extras = self.policy.get_observation(env_data, ctrl_data)
+            policy_pd = self.policy.get_pd_target(obs)
 
-            blend_ratio = np.minimum(t / 300, 1)
-            action = (1 - blend_ratio) * current_motor_angle + blend_ratio * desired_motor_angle
-
-            # warm up network
-            self.step(dry_run=True)
+            action = (1 - alpha) * self._init_dof_pos + alpha * policy_pd
 
             self.env.step(action)
 
@@ -196,14 +283,103 @@ class RlPipeline(Pipeline):
                 logger.error("Warning: frame drop")
             last_step_time = time.time()
             pbar.update()
-
-            if t == 0.9 * traj_len:
-                logger.info(f"{'=' * 10} RESET ZERO POSITION {'=' * 10}")
-                self.reset()
-
-        time.sleep(0.01)
         pbar.close()
-        logger.warning("prepare_done")
+
+        # Switch to motion tracking — policy sees the jump.
+        self._set_default_pose_mode(False)
+        logger.warning("Blend-in done — motion starting")
+
+    def prepare(self, init_motor_angle=None, prepare_seconds=None):
+        if init_motor_angle is not None:
+            desired_motor_angle = init_motor_angle
+        elif self._has_default_pose_mode:
+            # Ramp to the env's default standing pose (not motion frame 0).
+            desired_motor_angle = np.array(
+                self.env.dof_cfg.default_pos, dtype=np.float32
+            )
+        else:
+            desired_motor_angle = self.policy.get_init_dof_pos()
+
+        # Convert seconds to steps (at policy frequency).
+        # Default: 3s ramp + 5s blend.  CLI --prepare-seconds overrides both.
+        if prepare_seconds is not None:
+            ramp_steps = int(prepare_seconds * self.freq)
+            blend_steps = int(prepare_seconds * self.freq)
+        else:
+            ramp_steps = int(3.0 * self.freq)
+            blend_steps = int(5.0 * self.freq)
+
+        # ── Phase 1: Ramp joints to default pose ──
+        logger.warning(
+            f"prepare: phase 1 — ramp joints ({ramp_steps} steps, "
+            f"{ramp_steps / self.freq:.1f}s)"
+        )
+        pbar = ProgressBar("Prepare: ramp joints", ramp_steps)
+
+        last_step_time = time.time()
+        for t in range(ramp_steps):
+            current_motor_angle = np.array(self.env.dof_pos)
+            alpha = min(t / max(ramp_steps - 1, 1), 1.0)
+            action = (1 - alpha) * current_motor_angle + alpha * desired_motor_angle
+
+            self.env.step(action)
+
+            time_diff = last_step_time + self.dt - time.time()
+            if time_diff > 0:
+                time.sleep(time_diff)
+            else:
+                logger.error("Warning: frame drop")
+            last_step_time = time.time()
+            pbar.update()
+        pbar.close()
+
+        # Reset policy for a clean start — frame goes back to 0.
+        self.reset()
+        self._prepare_seconds = prepare_seconds  # restore after reset
+
+        # ── Phase 2: Blend in policy (holding default pose) ──
+        # Policy runs in default-pose mode (if supported): it sees synthetic
+        # references for the standing pose, not the real motion.
+        # Actions blend from raw default DOF to policy output.
+        self._set_default_pose_mode(True)
+
+        logger.warning(
+            f"prepare: phase 2 — blend policy ({blend_steps} steps, "
+            f"{blend_steps / self.freq:.1f}s)"
+        )
+        pbar = ProgressBar("Prepare: blend policy", blend_steps)
+
+        last_step_time = time.time()
+        for t in range(blend_steps):
+            alpha = t / max(blend_steps - 1, 1)
+
+            # Run policy observation + action (frame stays at 0).
+            self.env.update()
+            env_data = self.env.get_data()
+            ctrl_data = self.ctrl_manager.get_ctrl_data(env_data)
+            obs, extras = self.policy.get_observation(env_data, ctrl_data)
+            policy_pd = self.policy.get_pd_target(obs)
+
+            # Blend: default DOF → policy output
+            action = (1 - alpha) * desired_motor_angle + alpha * policy_pd
+
+            self.env.step(action)
+
+            # Do NOT call post_step_callback — frame stays at 0.
+
+            time_diff = last_step_time + self.dt - time.time()
+            if time_diff > 0:
+                time.sleep(time_diff)
+            else:
+                logger.error("Warning: frame drop")
+            last_step_time = time.time()
+            pbar.update()
+        pbar.close()
+
+        # ── Phase 3: Hold default pose — wait for R to start motion ──
+        # Stay in default-pose mode. Motion starts when [MOTION_RESET] is
+        # received (user presses R), which calls _set_default_pose_mode(False).
+        logger.warning("prepare done — holding default pose, press R to start motion")
 
 
 if __name__ == "__main__":

--- a/robojudo/policy/protomotions_tracker_policy.py
+++ b/robojudo/policy/protomotions_tracker_policy.py
@@ -22,11 +22,8 @@ Sensor requirements (real G1)
 - ``env_data.torso_quat`` (xyzw) -- FK-computed (requires ``update_with_fk=True``)
 """
 
-import importlib
 import logging
 import re
-import sys
-from pathlib import Path
 
 import numpy as np
 import onnxruntime as ort
@@ -35,33 +32,14 @@ import yaml
 from robojudo.policy import Policy, policy_registry
 from robojudo.policy.policy_cfgs import PolicyCfg
 from robojudo.tools.tool_cfgs import DoFConfig
-
-logger = logging.getLogger(__name__)
-
-# Add the protomotions repo root to sys.path so deployment.* is importable.
-# robojudo/robojudo/policy/this_file.py -> parents[2] = robojudo repo root
-# protomotions is expected as a sibling: ../protomotions
-_PROTO_ROOT = str(Path(__file__).resolve().parents[2].parent / "protomotions")
-if _PROTO_ROOT not in sys.path:
-    sys.path.insert(0, _PROTO_ROOT)
-
-
-try:
-    importlib.import_module("deployment")
-except ModuleNotFoundError:
-    logger.error(
-        "Missing ProtoMotions source repository: cannot import 'deployment'. "
-        "Please clone the original 'protomotions' repo as a sibling directory "
-        f"next to this repo (expected path: {_PROTO_ROOT})."
-    )
-    raise RuntimeError("Cannot import 'deployment' from ProtoMotions repo!") from None
-
-from deployment.motion_utils import MotionPlayer  # noqa: E402
-from deployment.state_utils import (  # noqa: E402
+from robojudo.utils.motion_utils import (
+    MotionPlayer,
     _extract_yaw_quat_np,
     apply_heading_offset_np,
     compute_yaw_offset_np,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @policy_registry.register
@@ -156,17 +134,21 @@ class ProtoMotionsTrackerPolicy(Policy):
         self._heading_offset = None
         self.reset()
 
-    def _resolve_default_dof_pos(self, joint_names: list[str]) -> np.ndarray:
-        """Resolve default DOF positions from protomotions G1 robot config.
+    # G1 default standing pose (from protomotions.robot_configs.g1)
+    _G1_DEFAULT_JOINT_POS = {
+        ".*_hip_pitch_joint": -0.312,
+        ".*_knee_joint": 0.669,
+        ".*_ankle_pitch_joint": -0.363,
+        ".*_elbow_joint": 0.6,
+        "left_shoulder_roll_joint": 0.2,
+        "left_shoulder_pitch_joint": 0.2,
+        "right_shoulder_roll_joint": -0.2,
+        "right_shoulder_pitch_joint": 0.2,
+    }
 
-        Uses regex-pattern matching from the robot config's DEFAULT_JOINT_POS
-        against the policy's joint names.
-        """
-        try:
-            from protomotions.robot_configs.g1 import DEFAULT_JOINT_POS
-        except ImportError:
-            logger.warning("[TrackerPolicy] Could not import G1 robot config — default pose will be zeros")
-            return np.zeros(len(joint_names), dtype=np.float32)
+    def _resolve_default_dof_pos(self, joint_names: list[str]) -> np.ndarray:
+        """Resolve default DOF positions via regex-pattern matching."""
+        DEFAULT_JOINT_POS = self._G1_DEFAULT_JOINT_POS
 
         default_pos = np.zeros(len(joint_names), dtype=np.float32)
         for pattern, value in DEFAULT_JOINT_POS.items():

--- a/robojudo/policy/protomotions_tracker_policy.py
+++ b/robojudo/policy/protomotions_tracker_policy.py
@@ -24,6 +24,7 @@ Sensor requirements (real G1)
 
 import importlib
 import logging
+import re
 import sys
 from pathlib import Path
 
@@ -57,6 +58,7 @@ except ModuleNotFoundError:
 
 from deployment.motion_utils import MotionPlayer  # noqa: E402
 from deployment.state_utils import (  # noqa: E402
+    _extract_yaw_quat_np,
     apply_heading_offset_np,
     compute_yaw_offset_np,
 )
@@ -148,8 +150,42 @@ class ProtoMotionsTrackerPolicy(Policy):
             f"anchor_idx={self._anchor_idx}, root_idx={self._root_idx}"
         )
 
+        # Resolve default standing pose from protomotions robot config.
+        self._default_dof_pos = self._resolve_default_dof_pos(joint_names)
+
         self._heading_offset = None
         self.reset()
+
+    def _resolve_default_dof_pos(self, joint_names: list[str]) -> np.ndarray:
+        """Resolve default DOF positions from protomotions G1 robot config.
+
+        Uses regex-pattern matching from the robot config's DEFAULT_JOINT_POS
+        against the policy's joint names.
+        """
+        try:
+            from protomotions.robot_configs.g1 import DEFAULT_JOINT_POS
+        except ImportError:
+            logger.warning("[TrackerPolicy] Could not import G1 robot config — default pose will be zeros")
+            return np.zeros(len(joint_names), dtype=np.float32)
+
+        default_pos = np.zeros(len(joint_names), dtype=np.float32)
+        for pattern, value in DEFAULT_JOINT_POS.items():
+            for i, name in enumerate(joint_names):
+                if re.fullmatch(pattern, name):
+                    default_pos[i] = value
+        logger.info(f"[TrackerPolicy] resolved default DOF pos: {default_pos}")
+        return default_pos
+
+    def set_default_pose_mode(self, enabled: bool):
+        """Switch between tracking real motion and holding default pose.
+
+        When enabled, the policy sees synthetic references for the default
+        standing pose instead of the real motion.  Used during prepare/rampdown.
+        """
+        self._default_pose_mode = enabled
+        if enabled:
+            self._motion_done = False
+        logger.info(f"[TrackerPolicy] default_pose_mode={'ON' if enabled else 'OFF'}")
 
     def reset(self):
         self._frame = 0
@@ -160,12 +196,13 @@ class ProtoMotionsTrackerPolicy(Policy):
         self._prev_actions = np.zeros(self.num_actions, dtype=np.float32)
         self._motion_done = False
         self._paused = False
+        self._default_pose_mode = False
 
     def reset_alignment(self):
         self._heading_offset = None
 
     def post_step_callback(self, commands=None):
-        if not self._paused:
+        if not self._paused and not self._default_pose_mode:
             self._frame += 1
             if self._frame >= self._player.total_frames:
                 self._frame = self._player.total_frames - 1
@@ -177,13 +214,9 @@ class ProtoMotionsTrackerPolicy(Policy):
     def get_observation(self, env_data, ctrl_data):
         # -- Heading alignment (first step after reset) --
         if self._heading_offset is None:
-            motion_anchor_rot = self._player.get_state_at_frame(0)["body_rot"][
-                self._anchor_idx
-            ]
+            motion_anchor_rot = self._player.get_state_at_frame(0)["body_rot"][self._anchor_idx]
             robot_anchor_rot = self._get_anchor_quat(env_data)
-            self._heading_offset = compute_yaw_offset_np(
-                robot_anchor_rot, motion_anchor_rot
-            )
+            self._heading_offset = compute_yaw_offset_np(robot_anchor_rot, motion_anchor_rot)
 
         # -- State from env_data (already xyzw) --
         anchor_rot = self._get_anchor_quat(env_data)
@@ -195,23 +228,29 @@ class ProtoMotionsTrackerPolicy(Policy):
         # as root_local_ang_vel -- NO quat_rotate_inverse needed.
         root_local_ang_vel = np.asarray(env_data.base_ang_vel, dtype=np.float32)
 
-        # -- Future motion references with heading alignment --
-        # Clamp each future step so it never exceeds the last valid frame.
-        # This repeats the last frame's references at end-of-motion instead
-        # of going out of bounds.
-        last_frame = self._player.total_frames - 1
-        clamped_steps = [
-            min(self._frame + step, last_frame) - self._frame
-            for step in self._future_step_indices
-        ]
-        future_refs = self._player.get_future_references(
-            self._frame, clamped_steps
-        )
-        future_body_rot = apply_heading_offset_np(
-            self._heading_offset, future_refs["body_rot"]
-        )
-        # Anchor-body-only rotation: [num_steps, 4]
-        future_anchor_rot = future_body_rot[:, self._anchor_idx, :]
+        if self._default_pose_mode:
+            # -- Synthetic references: hold default standing pose --
+            # Target DOFs = default standing pose, velocities = zero,
+            # anchor rotation = yaw-only from robot's current anchor (hold
+            # heading but neutral pitch/roll for stable upright standing).
+            num_steps = len(self._future_step_indices)
+            anchor_yaw_only = _extract_yaw_quat_np(anchor_rot)
+            future_anchor_rot = np.tile(anchor_yaw_only, (num_steps, 1))
+            future_dof_pos = np.tile(self._default_dof_pos, (num_steps, 1))
+            future_dof_vel = np.zeros_like(future_dof_pos)
+        else:
+            # -- Future motion references with heading alignment --
+            # Clamp each future step so it never exceeds the last valid frame.
+            # This repeats the last frame's references at end-of-motion instead
+            # of going out of bounds.
+            last_frame = self._player.total_frames - 1
+            clamped_steps = [min(self._frame + step, last_frame) - self._frame for step in self._future_step_indices]
+            future_refs = self._player.get_future_references(self._frame, clamped_steps)
+            future_body_rot = apply_heading_offset_np(self._heading_offset, future_refs["body_rot"])
+            # Anchor-body-only rotation: [num_steps, 4]
+            future_anchor_rot = future_body_rot[:, self._anchor_idx, :]
+            future_dof_pos = future_refs["dof_pos"]
+            future_dof_vel = future_refs["dof_vel"]
 
         # -- Build ONNX inputs --
         key_to_array = {
@@ -220,8 +259,8 @@ class ProtoMotionsTrackerPolicy(Policy):
             "current.anchor_rot": anchor_rot[None],
             "current.root_local_ang_vel": root_local_ang_vel[None],
             "mimic.future_anchor_rot": future_anchor_rot[None],
-            "mimic.future_dof_pos": future_refs["dof_pos"][None],
-            "mimic.future_dof_vel": future_refs["dof_vel"][None],
+            "mimic.future_dof_pos": future_dof_pos[None],
+            "mimic.future_dof_vel": future_dof_vel[None],
             "historical.processed_actions": self._prev_actions[None, None],
         }
         onnx_inputs = {}
@@ -261,7 +300,11 @@ class ProtoMotionsTrackerPolicy(Policy):
         self._stashed_pd_targets = pd_targets
         self._prev_actions = pd_targets.copy()
         extras = {
-            "CALLBACK": ["[MOTION_DONE]"] if self._motion_done else [],
+            "CALLBACK": (
+                ["[MOTION_DONE]"]
+                if self._motion_done and not self._default_pose_mode
+                else []
+            ),
         }
         dummy_obs = np.zeros(1, dtype=np.float32)
         return dummy_obs, extras

--- a/robojudo/utils/motion_utils.py
+++ b/robojudo/utils/motion_utils.py
@@ -220,28 +220,7 @@ class MotionPlayer:
         )
 
     def _load_raw(self, data: dict, motion_index: int, control_dt: float) -> None:
-        """Load from a raw ProtoMotions motion file and resample.
-
-        This path requires ``protomotions`` to be importable (for interpolation
-        utilities).  Use :meth:`cache_to_file` afterwards to create a cached
-        version that needs no external dependencies.
-        """
-        import torch
-
-        try:
-            from protomotions.utils.motion_interpolation_utils import (
-                calc_frame_blend,
-                interpolate_pos,
-                interpolate_quat,
-            )
-        except ImportError:
-            raise ImportError(
-                "Loading raw (non-cached) motion files requires the 'protomotions' "
-                "package for interpolation.  Either:\n"
-                "  1. Use a pre-cached .pt file (recommended), or\n"
-                "  2. Install protomotions: pip install protomotions"
-            ) from None
-
+        """Load from a raw ProtoMotions motion file and resample."""
         self._control_dt = control_dt
         self._cached = False
 
@@ -252,27 +231,26 @@ class MotionPlayer:
 
             start  = int(length_starts[motion_index].item())
             nf     = int(motion_num_frames[motion_index].item())
-            end    = start + nf
             src_dt = float(motion_dt_all[motion_index].item())
 
-            gts  = data["gts"][start:end]
-            grs  = data["grs"][start:end]
-            gvs  = data["gvs"][start:end]
-            gavs = data["gavs"][start:end]
-            dps  = data["dps"][start:end]
-            dvs  = data["dvs"][start:end]
+            gts  = np.asarray(data["gts"][start:start + nf],  dtype=np.float32)
+            grs  = np.asarray(data["grs"][start:start + nf],  dtype=np.float32)
+            gvs  = np.asarray(data["gvs"][start:start + nf],  dtype=np.float32)
+            gavs = np.asarray(data["gavs"][start:start + nf], dtype=np.float32)
+            dps  = np.asarray(data["dps"][start:start + nf],  dtype=np.float32)
+            dvs  = np.asarray(data["dvs"][start:start + nf],  dtype=np.float32)
             motion_length = src_dt * (nf - 1)
 
         elif "rigid_body_pos" in data:
             fps    = float(data["fps"])
             src_dt = 1.0 / fps
 
-            gts  = data["rigid_body_pos"]
-            grs  = data["rigid_body_rot"]
-            gvs  = data["rigid_body_vel"]
-            gavs = data["rigid_body_ang_vel"]
-            dps  = data["dof_pos"]
-            dvs  = data["dof_vel"]
+            gts  = np.asarray(data["rigid_body_pos"],     dtype=np.float32)
+            grs  = np.asarray(data["rigid_body_rot"],      dtype=np.float32)
+            gvs  = np.asarray(data["rigid_body_vel"],      dtype=np.float32)
+            gavs = np.asarray(data["rigid_body_ang_vel"],  dtype=np.float32)
+            dps  = np.asarray(data["dof_pos"],             dtype=np.float32)
+            dvs  = np.asarray(data["dof_vel"],             dtype=np.float32)
             nf   = gts.shape[0]
             motion_length = src_dt * (nf - 1)
         else:
@@ -282,48 +260,48 @@ class MotionPlayer:
                 "  - single-motion:   keys 'rigid_body_pos', 'fps', 'dof_pos', ..."
             )
 
+        # Resample to control rate (lerp for positions, slerp for quaternions)
         num_ctrl_frames = max(1, int(round(motion_length / control_dt)) + 1)
-        ctrl_times = torch.linspace(0.0, motion_length, num_ctrl_frames)
+        ctrl_times = np.linspace(0.0, motion_length, num_ctrl_frames)
 
-        motion_len_t  = torch.tensor([motion_length])
-        num_frames_t  = torch.tensor([nf])
-        motion_dt_t   = torch.tensor([src_dt])
+        phase = np.clip(ctrl_times / motion_length, 0.0, 1.0)
+        f0 = (phase * (nf - 1)).astype(np.int64)
+        f1 = np.minimum(f0 + 1, nf - 1)
+        blend = ((ctrl_times - f0 * src_dt) / src_dt).astype(np.float32)
 
-        f0_list, f1_list, blend_list = [], [], []
-        for t in ctrl_times:
-            t_t = t.unsqueeze(0)
-            f0, f1, bl = calc_frame_blend(t_t, motion_len_t, num_frames_t, motion_dt_t)
-            f0_list.append(f0)
-            f1_list.append(f1)
-            blend_list.append(bl)
+        def _lerp(src):
+            b = blend.reshape(-1, *([1] * (src.ndim - 1)))
+            return ((1.0 - b) * src[f0] + b * src[f1]).astype(np.float32)
 
-        f0    = torch.cat(f0_list)
-        f1    = torch.cat(f1_list)
-        blend = torch.cat(blend_list)
+        def _slerp(src):
+            q0, q1 = src[f0], src[f1]
+            cos_half = np.sum(q0 * q1, axis=-1, keepdims=True)
+            # Flip to shortest path
+            neg = cos_half < 0
+            q1 = np.where(neg, -q1, q1)
+            cos_half = np.abs(cos_half)
+            half_theta = np.arccos(np.clip(cos_half, -1.0, 1.0))
+            sin_half = np.sqrt(np.maximum(1.0 - cos_half * cos_half, 0.0))
+            b = blend.reshape(-1, *([1] * (q0.ndim - 1)))
+            # Safe divide — degenerate cases handled by np.where below
+            safe_sin = np.where(sin_half > 0, sin_half, 1.0)
+            ratio_a = np.sin((1.0 - b) * half_theta) / safe_sin
+            ratio_b = np.sin(b * half_theta) / safe_sin
+            result = ratio_a * q0 + ratio_b * q1
+            # Fallback: near-zero sin_half → linear blend; cos_half ≈ 1 → q0
+            near_zero = np.abs(sin_half) < 0.001
+            linear = 0.5 * q0 + 0.5 * q1
+            result = np.where(near_zero, linear, result)
+            identical = np.abs(cos_half) >= 1.0
+            result = np.where(identical, q0, result)
+            return result.astype(np.float32)
 
-        def _interp_pos(src):
-            s0 = src[f0]
-            s1 = src[f1]
-            return interpolate_pos(s0, s1, blend)
-
-        def _interp_quat(src):
-            s0 = src[f0]
-            s1 = src[f1]
-            return interpolate_quat(s0, s1, blend)
-
-        body_pos     = _interp_pos(gts)
-        body_rot     = _interp_quat(grs)
-        body_vel     = _interp_pos(gvs)
-        body_ang_vel = _interp_pos(gavs)
-        dof_pos      = _interp_pos(dps)
-        dof_vel      = _interp_pos(dvs)
-
-        self._dof_pos      = dof_pos.numpy().astype(np.float32)
-        self._dof_vel      = dof_vel.numpy().astype(np.float32)
-        self._body_rot     = body_rot.numpy().astype(np.float32)
-        self._body_pos     = body_pos.numpy().astype(np.float32)
-        self._body_vel     = body_vel.numpy().astype(np.float32)
-        self._body_ang_vel = body_ang_vel.numpy().astype(np.float32)
+        self._body_pos     = _lerp(gts)
+        self._body_rot     = _slerp(grs)
+        self._body_vel     = _lerp(gvs)
+        self._body_ang_vel = _lerp(gavs)
+        self._dof_pos      = _lerp(dps)
+        self._dof_vel      = _lerp(dvs)
         self._num_frames   = num_ctrl_frames
 
         print(

--- a/robojudo/utils/motion_utils.py
+++ b/robojudo/utils/motion_utils.py
@@ -1,0 +1,333 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 The ProtoMotions Developers
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Motion playback and heading-alignment utilities.
+
+Vendored from the ProtoMotions ``deployment`` module so that RoboJuDo can
+run inference without requiring the ProtoMotions source tree.
+
+Quaternion convention: **xyzw** throughout (ProtoMotions common format).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+import numpy as np
+
+__all__ = [
+    "MotionPlayer",
+    "compute_yaw_offset_np",
+    "apply_heading_offset_np",
+    "_extract_yaw_quat_np",
+]
+
+# ---------------------------------------------------------------------------
+# Quaternion helpers (pure NumPy)
+# ---------------------------------------------------------------------------
+
+
+def _extract_yaw_quat_np(q_xyzw: np.ndarray) -> np.ndarray:
+    """Extract the yaw-only quaternion from a full orientation (xyzw)."""
+    x, y, z, w = q_xyzw[0], q_xyzw[1], q_xyzw[2], q_xyzw[3]
+    yaw = np.arctan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
+    half = yaw * 0.5
+    return np.array([0.0, 0.0, np.sin(half), np.cos(half)], dtype=np.float32)
+
+
+def _quat_mul_np(a_xyzw: np.ndarray, b_xyzw: np.ndarray) -> np.ndarray:
+    """Hamilton product of two xyzw quaternions (pure NumPy)."""
+    ax, ay, az, aw = a_xyzw[..., 0], a_xyzw[..., 1], a_xyzw[..., 2], a_xyzw[..., 3]
+    bx, by, bz, bw = b_xyzw[..., 0], b_xyzw[..., 1], b_xyzw[..., 2], b_xyzw[..., 3]
+    return np.stack([
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+        aw * bw - ax * bx - ay * by - az * bz,
+    ], axis=-1).astype(np.float32)
+
+
+def _quat_conjugate_np(q_xyzw: np.ndarray) -> np.ndarray:
+    """Conjugate (inverse for unit quats) of an xyzw quaternion."""
+    result = q_xyzw.copy()
+    result[..., :3] *= -1.0
+    return result
+
+
+def compute_yaw_offset_np(
+    robot_quat_xyzw: np.ndarray,
+    motion_quat_xyzw: np.ndarray,
+) -> np.ndarray:
+    """Compute a yaw-only heading offset between robot and motion frames.
+
+    Returns a quaternion ``R_offset`` such that
+    ``R_offset * motion_body_rot`` is in the robot's heading frame.
+    """
+    robot_yaw = _extract_yaw_quat_np(robot_quat_xyzw)
+    motion_yaw = _extract_yaw_quat_np(motion_quat_xyzw)
+    return _quat_mul_np(robot_yaw, _quat_conjugate_np(motion_yaw))
+
+
+def apply_heading_offset_np(
+    offset_quat_xyzw: np.ndarray,
+    body_rots_xyzw: np.ndarray,
+) -> np.ndarray:
+    """Apply a heading offset to an array of body rotations.
+
+    Computes ``offset * body_rot`` for every quaternion in the array.
+    """
+    original_shape = body_rots_xyzw.shape
+    flat = body_rots_xyzw.reshape(-1, 4)
+    offset_broadcast = np.broadcast_to(offset_quat_xyzw, flat.shape)
+    aligned = _quat_mul_np(offset_broadcast, flat)
+    return aligned.reshape(original_shape)
+
+
+# ---------------------------------------------------------------------------
+# MotionPlayer
+# ---------------------------------------------------------------------------
+
+_STATE_KEYS = ("dof_pos", "dof_vel", "body_rot", "body_pos", "body_vel", "body_ang_vel")
+
+
+def _is_cache_file(data: dict) -> bool:
+    """Return True if *data* looks like a pre-resampled cache."""
+    return "control_dt" in data and "body_rot" in data
+
+
+class MotionPlayer:
+    """Lightweight player for a single motion clip at a fixed control rate.
+
+    Accepts three input formats (auto-detected):
+
+    1. Single ``.motion`` file -- RobotState dict with ``fps``, ``dof_pos``, etc.
+    2. Packaged ``.pt`` library -- multi-motion with ``length_starts``, ``gts``, etc.
+       Requires ``motion_index``.
+    3. Pre-resampled cache -- written by :meth:`cache_to_file`.
+
+    Formats 1 and 2 require ``protomotions`` for interpolation on first load.
+    Format 3 (cached) is pure NumPy -- no external dependencies.
+    """
+
+    def __init__(
+        self,
+        motion_file: str,
+        motion_index: int = 0,
+        control_dt: float = 0.02,
+    ):
+        import torch
+
+        self._torch = torch
+        motion_file = str(motion_file)
+        data = torch.load(motion_file, map_location="cpu", weights_only=False)
+
+        if _is_cache_file(data):
+            self._load_cache(data)
+        else:
+            self._load_raw(data, motion_index, control_dt)
+
+    @property
+    def total_frames(self) -> int:
+        return self._num_frames
+
+    @property
+    def num_bodies(self) -> int:
+        return self._body_rot.shape[1]
+
+    @property
+    def num_dofs(self) -> int:
+        return self._dof_pos.shape[1]
+
+    @property
+    def control_dt(self) -> float:
+        return self._control_dt
+
+    def get_state_at_frame(self, frame_idx: int) -> Dict[str, np.ndarray]:
+        """Return the motion state at *frame_idx* (clamped)."""
+        idx = int(np.clip(frame_idx, 0, self._num_frames - 1))
+        return {
+            "dof_pos":      self._dof_pos[idx],
+            "dof_vel":      self._dof_vel[idx],
+            "body_rot":     self._body_rot[idx],
+            "body_pos":     self._body_pos[idx],
+            "body_vel":     self._body_vel[idx],
+            "body_ang_vel": self._body_ang_vel[idx],
+        }
+
+    def get_future_references(
+        self,
+        frame_idx: int,
+        step_indices: List[int],
+    ) -> Dict[str, np.ndarray]:
+        """Return stacked future motion states at ``frame_idx + offset``."""
+        future_states = [
+            self.get_state_at_frame(frame_idx + s) for s in step_indices
+        ]
+        return {
+            key: np.stack([s[key] for s in future_states], axis=0)
+            for key in _STATE_KEYS
+        }
+
+    def cache_to_file(self, output_path: str) -> None:
+        """Write a pre-resampled cache file at the current control rate."""
+        import torch
+
+        cache = {
+            "dof_pos":      self._dof_pos,
+            "dof_vel":      self._dof_vel,
+            "body_rot":     self._body_rot,
+            "body_pos":     self._body_pos,
+            "body_vel":     self._body_vel,
+            "body_ang_vel": self._body_ang_vel,
+            "control_dt":   self._control_dt,
+            "num_frames":   self._num_frames,
+        }
+        torch.save(cache, output_path)
+        print(
+            f"[MotionPlayer] Cached {self._num_frames} frames @ "
+            f"{1.0 / self._control_dt:.0f} Hz -> {output_path}"
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load_cache(self, data: dict) -> None:
+        self._dof_pos      = np.asarray(data["dof_pos"],      dtype=np.float32)
+        self._dof_vel      = np.asarray(data["dof_vel"],      dtype=np.float32)
+        self._body_rot     = np.asarray(data["body_rot"],     dtype=np.float32)
+        self._body_pos     = np.asarray(data["body_pos"],     dtype=np.float32)
+        self._body_vel     = np.asarray(data["body_vel"],     dtype=np.float32)
+        self._body_ang_vel = np.asarray(data["body_ang_vel"], dtype=np.float32)
+        self._control_dt   = float(data["control_dt"])
+        self._num_frames   = int(data["num_frames"])
+        self._cached = True
+        print(
+            f"[MotionPlayer] Loaded cache: {self._num_frames} frames "
+            f"@ {1.0 / self._control_dt:.0f} Hz"
+        )
+
+    def _load_raw(self, data: dict, motion_index: int, control_dt: float) -> None:
+        """Load from a raw ProtoMotions motion file and resample.
+
+        This path requires ``protomotions`` to be importable (for interpolation
+        utilities).  Use :meth:`cache_to_file` afterwards to create a cached
+        version that needs no external dependencies.
+        """
+        import torch
+
+        try:
+            from protomotions.utils.motion_interpolation_utils import (
+                calc_frame_blend,
+                interpolate_pos,
+                interpolate_quat,
+            )
+        except ImportError:
+            raise ImportError(
+                "Loading raw (non-cached) motion files requires the 'protomotions' "
+                "package for interpolation.  Either:\n"
+                "  1. Use a pre-cached .pt file (recommended), or\n"
+                "  2. Install protomotions: pip install protomotions"
+            ) from None
+
+        self._control_dt = control_dt
+        self._cached = False
+
+        if "length_starts" in data:
+            length_starts     = data["length_starts"]
+            motion_num_frames = data["motion_num_frames"]
+            motion_dt_all     = data["motion_dt"]
+
+            start  = int(length_starts[motion_index].item())
+            nf     = int(motion_num_frames[motion_index].item())
+            end    = start + nf
+            src_dt = float(motion_dt_all[motion_index].item())
+
+            gts  = data["gts"][start:end]
+            grs  = data["grs"][start:end]
+            gvs  = data["gvs"][start:end]
+            gavs = data["gavs"][start:end]
+            dps  = data["dps"][start:end]
+            dvs  = data["dvs"][start:end]
+            motion_length = src_dt * (nf - 1)
+
+        elif "rigid_body_pos" in data:
+            fps    = float(data["fps"])
+            src_dt = 1.0 / fps
+
+            gts  = data["rigid_body_pos"]
+            grs  = data["rigid_body_rot"]
+            gvs  = data["rigid_body_vel"]
+            gavs = data["rigid_body_ang_vel"]
+            dps  = data["dof_pos"]
+            dvs  = data["dof_vel"]
+            nf   = gts.shape[0]
+            motion_length = src_dt * (nf - 1)
+        else:
+            raise ValueError(
+                "Unrecognised raw motion format.  Expected either:\n"
+                "  - packaged library: keys 'length_starts', 'gts', 'grs', ...\n"
+                "  - single-motion:   keys 'rigid_body_pos', 'fps', 'dof_pos', ..."
+            )
+
+        num_ctrl_frames = max(1, int(round(motion_length / control_dt)) + 1)
+        ctrl_times = torch.linspace(0.0, motion_length, num_ctrl_frames)
+
+        motion_len_t  = torch.tensor([motion_length])
+        num_frames_t  = torch.tensor([nf])
+        motion_dt_t   = torch.tensor([src_dt])
+
+        f0_list, f1_list, blend_list = [], [], []
+        for t in ctrl_times:
+            t_t = t.unsqueeze(0)
+            f0, f1, bl = calc_frame_blend(t_t, motion_len_t, num_frames_t, motion_dt_t)
+            f0_list.append(f0)
+            f1_list.append(f1)
+            blend_list.append(bl)
+
+        f0    = torch.cat(f0_list)
+        f1    = torch.cat(f1_list)
+        blend = torch.cat(blend_list)
+
+        def _interp_pos(src):
+            s0 = src[f0]
+            s1 = src[f1]
+            return interpolate_pos(s0, s1, blend)
+
+        def _interp_quat(src):
+            s0 = src[f0]
+            s1 = src[f1]
+            return interpolate_quat(s0, s1, blend)
+
+        body_pos     = _interp_pos(gts)
+        body_rot     = _interp_quat(grs)
+        body_vel     = _interp_pos(gvs)
+        body_ang_vel = _interp_pos(gavs)
+        dof_pos      = _interp_pos(dps)
+        dof_vel      = _interp_pos(dvs)
+
+        self._dof_pos      = dof_pos.numpy().astype(np.float32)
+        self._dof_vel      = dof_vel.numpy().astype(np.float32)
+        self._body_rot     = body_rot.numpy().astype(np.float32)
+        self._body_pos     = body_pos.numpy().astype(np.float32)
+        self._body_vel     = body_vel.numpy().astype(np.float32)
+        self._body_ang_vel = body_ang_vel.numpy().astype(np.float32)
+        self._num_frames   = num_ctrl_frames
+
+        print(
+            f"[MotionPlayer] Loaded raw motion #{motion_index}: "
+            f"{nf} source frames @ {1.0 / src_dt:.1f} Hz -> "
+            f"{num_ctrl_frames} resampled frames @ {1.0 / control_dt:.0f} Hz"
+        )

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -46,6 +46,9 @@ def main():
 
     if not cfg.env.is_sim:
         pipeline.prepare()
+    elif getattr(pipeline, "_has_default_pose_mode", False):
+        pipeline._set_default_pose_mode(True)
+        logger.warning("Sim mode — holding default pose, press R to start motion")
 
     while True:
         time_start = time.time()

--- a/scripts/run_tracker_pipeline.py
+++ b/scripts/run_tracker_pipeline.py
@@ -1,7 +1,8 @@
 """Run a ProtoMotions tracker policy.
 
-Extends the generic pipeline runner with tracker-specific CLI overrides
-for ONNX model, motion file, and motion index.
+Extends the generic pipeline runner with tracker-specific features:
+- CLI overrides for ONNX model, motion file, and motion index
+- Default-pose mode: hold standing pose until R is pressed
 
 Usage::
 
@@ -84,6 +85,10 @@ def main():
 
     if not cfg.env.is_sim:
         pipeline.prepare()
+    elif pipeline._has_default_pose_mode:
+        # In sim without prepare: hold default pose until R is pressed.
+        pipeline._set_default_pose_mode(True)
+        logger.warning("Sim mode — holding default pose, press R to start motion")
 
     while True:
         time_start = time.time()


### PR DESCRIPTION
The tracker policy currently requires the `protomotions` repo cloned as a sibling directory to import `deployment.motion_utils` and `deployment.state_utils`. This causes `ModuleNotFoundError: No module named 'deployment'` for anyone whose directory layout doesn't match.

This PR vendors the needed logic into RoboJuDo so the tracker works standalone:

- **`robojudo/utils/motion_utils.py`** (new): `MotionPlayer` class and heading-alignment quaternion helpers, copied from protomotions `deployment/` module. Raw motion resampling uses inline NumPy lerp/slerp instead of importing `protomotions.utils.motion_interpolation_utils`.
- **Tracker policy**: imports from `robojudo.utils.motion_utils` instead of `deployment.*`. G1 default joint positions inlined as a class constant.
- **`run_pipeline.py`**: in sim mode, policies that support default-pose mode now hold standing pose on startup until R is pressed.
- **Pipeline enhancements**: default-pose mode, blend-in/out phases, random heading on spawn.